### PR TITLE
Feature/router and routes

### DIFF
--- a/Scout/src/server/controllers/createUpdateControllers.js
+++ b/Scout/src/server/controllers/createUpdateControllers.js
@@ -58,7 +58,8 @@ const createUpdateControllers = {
       note_id,
       interview_status,
       tags,
-      job_id,user_id
+      job_id,
+      user_id
       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
       RETURNING status_id;`;
 
@@ -188,6 +189,28 @@ const createUpdateControllers = {
         console.error(`Error creating annoucnement ${error}`)
         res.status(500).send(`Error, could not create announcement`)
       }
+  },
+
+  updateJob: async (req, res) => {
+    const { jobID, jobDetails } = req.body
+    let jobQuery = `UPDATE partner_jobs SET`;
+    const jobParams = [];
+
+    Object.keys(jobDetails).forEach((key, index) => {
+      jobQuery += ` ${key} = $${index + 1},`
+      jobParams.push(jobDetails[key])
+    });
+    jobQuery = jobQuery.slice(0, -1);
+    jobQuery += ` WHERE job_id = $${jobParams.length + 1} RETURNING *`;
+    jobParams.push(jobID);
+
+    try {
+      const results = await db.query(jobQuery, jobParams)
+      res.status(200).send(results.rows)
+    } catch(error) {
+      console.error(`Error updating job ${error}`)
+      res.status(500).send(`Error, could not update job`)
+    }
   }
 }
 

--- a/Scout/src/server/routes/createUpdateRoutes.js
+++ b/Scout/src/server/routes/createUpdateRoutes.js
@@ -3,13 +3,14 @@ import express from 'express';
 
 const router = express.Router();
 
-import createUpdateControllers from '../controllers/createUpdateControllers.js'
+import createUpdateControllers from '../controllers/createUpdateControllers.js';
 
 
 router.put('/addjob', createUpdateControllers.addJob);
 router.put('/addjobaddstatus/:id', createUpdateControllers.addJobAddStatus);
 router.put('/updatestatus', createUpdateControllers.updateJobStatus);
 router.put('/notifications/:id', createUpdateControllers.addNotification);
-router.put('/updatenotifications/:id', createUpdateControllers.updateNotification)
-router.put('/announcements/:id', createUpdateControllers.addAnnouncement)
+router.put('/updatenotifications/:id', createUpdateControllers.updateNotification);
+router.put('/announcements/:id', createUpdateControllers.addAnnouncement);
+router.put('/updatejob', createUpdateControllers.updateJob);
 export default router;


### PR DESCRIPTION
Added update Job route for administrators to update partner jobs for the public job board. Same flexibility as in the updateJobStatus route for the students. Include as many or as few fields as you would like so long as the jobID and jobDetails objects are present with at least one value.